### PR TITLE
Add redirects for moved documentation pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,8 @@ plugins:
       enable_creation_date: true
   - redirects:
       redirect_maps:
-        'mkdocs-syntax-examples/index.md': 'docs/mkdocs-syntax-examples/index.md'
-        'media/video-encoding/benchmark-with-ffmpeg/index.md': 'docs/media/video-encoding/benchmark-with-ffmpeg/index.md'
+        'mkdocs-syntax-examples/index.md': 'docs/mkdocs-syntax-examples.md'
+        'media/video-encoding/benchmark-with-ffmpeg/index.md': 'docs/media/video-encoding/benchmark-with-ffmpeg.md'
 
 markdown_extensions:
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,10 @@ plugins:
       type: timeago
       fallback_to_build_date: false
       enable_creation_date: true
+  - redirects:
+      redirect_maps:
+        'mkdocs-syntax-examples/index.md': 'docs/mkdocs-syntax-examples/index.md'
+        'media/video-encoding/benchmark-with-ffmpeg/index.md': 'docs/media/video-encoding/benchmark-with-ffmpeg/index.md'
 
 markdown_extensions:
   - attr_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-awesome-nav
 mkdocs-git-revision-date-localized-plugin
 mkdocs-glightbox
 click==8.2.1
+mkdocs-redirects


### PR DESCRIPTION
## Summary
- Add `mkdocs-redirects` plugin to `requirements.txt`
- Configure redirect maps in `mkdocs.yml` for two moved pages:
  - `mkdocs-syntax-examples/` → `docs/mkdocs-syntax-examples/`
  - `media/video-encoding/benchmark-with-ffmpeg/` → `docs/media/video-encoding/benchmark-with-ffmpeg/`

## Test plan
- [ ] Run `pip install -r requirements.txt` to install the new dependency
- [ ] Run `mkdocs build` and verify redirects are generated
- [ ] Check that old URLs redirect to the new locations

https://claude.ai/code/session_01BfFf2M5Rzsyp89EM7V6riL